### PR TITLE
Bump lens upper version bounds

### DIFF
--- a/cabal-lenses.cabal
+++ b/cabal-lenses.cabal
@@ -23,7 +23,7 @@ source-repository head
 library
     build-depends:
         base >=3 && <5,
-        lens >=4.0.1 && <4.5,
+        lens >=4.0.1 && <4.6,
         unordered-containers >=0.2.3.3 && <0.3,
         Cabal >=1.16.0 && <1.21
     exposed-modules:


### PR DESCRIPTION
Allow `cabal-lenses` to use the latest version of `lens` (4.5).
