### PR TITLE
automatically derive lenses with `makeLensesSuffixed`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# .gitignore
+
+# my
+ignore/
+notes
+goals
+TODO
+.projectile
+TAGS 
+
+# Haskell
+dist
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+.virtualenv
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+cabal.config
+report.html
+
+# Emacs
+\#*
+*~
+.#*
+\#*\#
+*.log
+TAGS
+
+# OS X
+.DS_Store
+

--- a/cabal-lenses.cabal
+++ b/cabal-lenses.cabal
@@ -1,5 +1,5 @@
 name: cabal-lenses
-version: 0.5.0
+version: 0.4.7
 cabal-version: >=1.9.2
 build-type: Simple
 license: BSD3
@@ -21,11 +21,16 @@ source-repository head
     location: https://github.com/dan-t/cabal-lenses
 
 library
+
+
     build-depends:
         lens >=4.0.1 && <4.14,
         unordered-containers >=0.2.3.3 && <0.3,
-        -- Cabal ==1.24.*,
-        Cabal >=1.16.0 && <1.23,
+
+        Cabal ==1.22.*,
+        -- for Cabal, we let the minor version vary, because any new fields/cases are either ignored or exported as new lenses (i.e. API additions only)
+        -- tested with: cabal install 'Cabal ==1.22.4.0' 
+
         either >=4.1.1 && <4.4,
         system-filepath >=0.4.9 && <0.5,
         system-fileio >=0.3.12 && <0.4,

--- a/cabal-lenses.cabal
+++ b/cabal-lenses.cabal
@@ -51,6 +51,7 @@ library
         CabalLenses.Traversals.Dependency
         CabalLenses.Utils
         CabalLenses.TH
+
     exposed: True
     buildable: True
     cpp-options: -DCABAL

--- a/cabal-lenses.cabal
+++ b/cabal-lenses.cabal
@@ -1,5 +1,5 @@
 name: cabal-lenses
-version: 0.4.6
+version: 0.5.0
 cabal-version: >=1.9.2
 build-type: Simple
 license: BSD3
@@ -11,7 +11,7 @@ description:
     the <https://hackage.haskell.org/package/Cabal Cabal> library.
 category: Utils, Development
 author: Daniel Trstenjak
-tested-with: GHC ==7.6.2 GHC ==7.6.3 GHC ==7.8.3 GHC ==7.10.1
+tested-with: GHC ==7.10.1
 extra-source-files:
     README.md
     CHANGELOG
@@ -19,11 +19,12 @@ extra-source-files:
 source-repository head
     type: git
     location: https://github.com/dan-t/cabal-lenses
- 
+
 library
     build-depends:
-        lens >=4.0.1 && <4.9,
+        lens >=4.0.1 && <4.14,
         unordered-containers >=0.2.3.3 && <0.3,
+        -- Cabal ==1.24.*,
         Cabal >=1.16.0 && <1.23,
         either >=4.1.1 && <4.4,
         system-filepath >=0.4.9 && <0.5,
@@ -31,6 +32,7 @@ library
         strict >=0.3.2 && <0.4,
         text >=1.1.0.1 && <1.3,
         transformers >=0.3.0.0 && <0.5, 
+        template-haskell >=2.7.0 && <2.11.0, 
         base >=3 && <5
     exposed-modules:
         CabalLenses
@@ -43,6 +45,7 @@ library
         CabalLenses.Traversals.BuildInfo
         CabalLenses.Traversals.Dependency
         CabalLenses.Utils
+        CabalLenses.TH
     exposed: True
     buildable: True
     cpp-options: -DCABAL

--- a/cabal-lenses.cabal
+++ b/cabal-lenses.cabal
@@ -22,7 +22,6 @@ source-repository head
  
 library
     build-depends:
-        base >=3 && <5,
         lens >=4.0.1 && <4.9,
         unordered-containers >=0.2.3.3 && <0.3,
         Cabal >=1.16.0 && <1.23,
@@ -31,7 +30,8 @@ library
         system-fileio >=0.3.12 && <0.4,
         strict >=0.3.2 && <0.4,
         text >=1.1.0.1 && <1.3,
-        transformers >=0.3.0.0 && <0.5
+        transformers >=0.3.0.0 && <0.5, 
+        base >=3 && <5
     exposed-modules:
         CabalLenses
         CabalLenses.PackageDescription
@@ -39,6 +39,7 @@ library
         CabalLenses.Version
         CabalLenses.CondVars
         CabalLenses.Section
+        CabalLenses.Traversals.Internal
         CabalLenses.Traversals.BuildInfo
         CabalLenses.Traversals.Dependency
         CabalLenses.Utils
@@ -47,8 +48,6 @@ library
     cpp-options: -DCABAL
     hs-source-dirs: lib
     other-modules:
-        CabalLenses.Traversals.Internal
         Paths_cabal_lenses
-    ghc-options: -W
- 
- 
+    ghc-options: -Wall
+

--- a/lib/CabalLenses/CondVars.hs
+++ b/lib/CabalLenses/CondVars.hs
@@ -1,7 +1,7 @@
 {-# Language TemplateHaskell, PatternGuards #-}
 
 module CabalLenses.CondVars where
-import CabalLenses.TH (suffixedFields) 
+import CabalLenses.TH (makeLensesSuffixed) 
 
 import qualified Distribution.PackageDescription as PD
 import Distribution.PackageDescription (Condition(..))
@@ -27,9 +27,7 @@ data CondVars = CondVars
    , compilerVersion :: Maybe Version    -- ^ the user specified compiler version
    } deriving (Show)
 
-
-makeLensesWith suffixedFields ''CondVars
-
+makeLensesSuffixed ''CondVars
 
 -- | Create a 'CondVars' from the default flags of the cabal package description.
 --   The 'os', 'arch' and 'compilerFlavor' fields are initialized by the ones the cabal library was build on.

--- a/lib/CabalLenses/CondVars.hs
+++ b/lib/CabalLenses/CondVars.hs
@@ -1,12 +1,7 @@
 {-# Language TemplateHaskell, PatternGuards #-}
 
-module CabalLenses.CondVars
-   ( CondVars(..)
-   , fromDefaults
-   , enableFlag
-   , disableFlag
-   , eval
-   ) where
+module CabalLenses.CondVars where
+import CabalLenses.TH (suffixedFields) 
 
 import qualified Distribution.PackageDescription as PD
 import Distribution.PackageDescription (Condition(..))
@@ -33,8 +28,7 @@ data CondVars = CondVars
    } deriving (Show)
 
 
-makeLensesFor [ ("flags", "flagsL")
-              ] ''CondVars
+makeLensesWith suffixedFields ''CondVars
 
 
 -- | Create a 'CondVars' from the default flags of the cabal package description.
@@ -90,3 +84,4 @@ eval condVars = eval'
 
          | otherwise
          = False
+

--- a/lib/CabalLenses/CondVars.hs
+++ b/lib/CabalLenses/CondVars.hs
@@ -40,14 +40,14 @@ makeLensesFor [ ("flags", "flagsL")
 -- | Create a 'CondVars' from the default flags of the cabal package description.
 --   The 'os', 'arch' and 'compilerFlavor' fields are initialized by the ones the cabal library was build on.
 fromDefaults :: PD.GenericPackageDescription -> CondVars
-fromDefaults pkgDescrp = CondVars { flags           = flags
+fromDefaults pkgDescrp = CondVars { flags           = theFlags 
                                   , os              = S.buildOS
                                   , arch            = S.buildArch
                                   , compilerFlavor  = buildCompilerFlavor
                                   , compilerVersion = Nothing
                                   }
    where
-      flags = HM.fromList $ map nameWithDflt (PD.genPackageFlags pkgDescrp)
+      theFlags = HM.fromList $ map nameWithDflt (PD.genPackageFlags pkgDescrp)
 
       nameWithDflt PD.MkFlag { PD.flagName = PD.FlagName name, PD.flagDefault = dflt } =
          (name, dflt)

--- a/lib/CabalLenses/Package.hs
+++ b/lib/CabalLenses/Package.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE TemplateHaskell, TypeFamilies, FlexibleInstances, MultiParamTypeClasses #-}
-
--- |
--- Lenses for several data types of the 'Distribution.Package' module.
--- All lenses are named after their field names with a 'L' appended.
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-| Lenses for several data types of the 'Distribution.Package' module.
+All lenses are named after their field names with a 'L' appended. 
+
+-}
 module CabalLenses.Package where
 import CabalLenses.TH (suffixedFields) 
 

--- a/lib/CabalLenses/Package.hs
+++ b/lib/CabalLenses/Package.hs
@@ -3,7 +3,7 @@
 -- |
 -- Lenses for several data types of the 'Distribution.Package' module.
 -- All lenses are named after their field names with a 'L' appended.
-
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module CabalLenses.Package where
 
 import Distribution.Package (PackageName(..) , PackageIdentifier(..) , Dependency(..))
@@ -28,12 +28,12 @@ instance Wrapped PackageName where
 packageName :: Lens' Dependency PackageName
 packageName = lens getPkgName setPkgName
    where
-      getPkgName (Dependency pkgName _)          = pkgName
-      setPkgName (Dependency _ range) newPkgName = Dependency newPkgName range
+      getPkgName (Dependency thePackageName _)       = thePackageName
+      setPkgName (Dependency _ range) thePackageName = Dependency thePackageName range
 
 
 versionRange :: Lens' Dependency VersionRange
 versionRange = lens getRange setRange
    where
-      getRange (Dependency _ range)   = range
-      setRange (Dependency pkgName _) = Dependency pkgName
+      getRange (Dependency _ range)          = range
+      setRange (Dependency thePackageName _) = Dependency thePackageName 

--- a/lib/CabalLenses/Package.hs
+++ b/lib/CabalLenses/Package.hs
@@ -5,15 +5,14 @@ All lenses are named after their field names with a 'L' appended.
 
 -}
 module CabalLenses.Package where
-import CabalLenses.TH (suffixedFields) 
+import CabalLenses.TH (makeLensesSuffixed) 
 
 import Distribution.Package (PackageName(..) , PackageIdentifier(..) , Dependency(..))
 import Distribution.Version (VersionRange)
 import Control.Lens
 
 
-makeLensesWith suffixedFields ''PackageIdentifier
-
+makeLensesSuffixed ''PackageIdentifier
 
 instance (t ~ PackageName) => Rewrapped PackageName t
 instance Wrapped PackageName where

--- a/lib/CabalLenses/Package.hs
+++ b/lib/CabalLenses/Package.hs
@@ -5,15 +5,14 @@
 -- All lenses are named after their field names with a 'L' appended.
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module CabalLenses.Package where
+import CabalLenses.TH (suffixedFields) 
 
 import Distribution.Package (PackageName(..) , PackageIdentifier(..) , Dependency(..))
 import Distribution.Version (VersionRange)
 import Control.Lens
 
 
-makeLensesFor [ ("pkgName"   , "pkgNameL")
-              , ("pkgVersion", "pkgVersionL")
-              ] ''PackageIdentifier
+makeLensesWith suffixedFields ''PackageIdentifier
 
 
 instance (t ~ PackageName) => Rewrapped PackageName t

--- a/lib/CabalLenses/PackageDescription.hs
+++ b/lib/CabalLenses/PackageDescription.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell, CPP #-}
 
 -- |
 -- Lenses for several data types of the 'Distribution.PackageDescription' module.
@@ -18,26 +18,19 @@ import Distribution.PackageDescription ( GenericPackageDescription(..)
                                        )
 import Control.Lens (makeLensesWith)
 
-
 makeLensesWith suffixedFields ''GenericPackageDescription
-
 
 makeLensesWith suffixedFields ''PackageDescription
 
-
 makeLensesWith suffixedFields ''Library
-
 
 makeLensesWith suffixedFields ''Executable
 
-
 makeLensesWith suffixedFields ''TestSuite
-
 
 makeLensesWith suffixedFields ''Benchmark
 
-
 makeLensesWith suffixedFields ''BuildInfo
 
-
 makeLensesWith suffixedFields ''CondTree
+

--- a/lib/CabalLenses/PackageDescription.hs
+++ b/lib/CabalLenses/PackageDescription.hs
@@ -5,8 +5,9 @@
 -- All lenses are named after their field names with a 'L' appended.
 
 module CabalLenses.PackageDescription where
-import CabalLenses.TH (suffixedFields) 
+import CabalLenses.TH (makeLensesSuffixed) 
 
+import Distribution.ModuleName (ModuleName) 
 import Distribution.PackageDescription ( GenericPackageDescription(..)
                                        , PackageDescription(..)
                                        , Library(..)
@@ -16,21 +17,33 @@ import Distribution.PackageDescription ( GenericPackageDescription(..)
                                        , BuildInfo(..)
                                        , CondTree(..)
                                        )
-import Control.Lens (makeLensesWith)
+import Control.Lens(Traversal',each) 
 
-makeLensesWith suffixedFields ''GenericPackageDescription
+makeLensesSuffixed ''GenericPackageDescription
 
-makeLensesWith suffixedFields ''PackageDescription
+makeLensesSuffixed ''PackageDescription
 
-makeLensesWith suffixedFields ''Library
+makeLensesSuffixed ''Library
 
-makeLensesWith suffixedFields ''Executable
+makeLensesSuffixed ''Executable
 
-makeLensesWith suffixedFields ''TestSuite
+makeLensesSuffixed ''TestSuite
 
-makeLensesWith suffixedFields ''Benchmark
+makeLensesSuffixed ''Benchmark
 
-makeLensesWith suffixedFields ''BuildInfo
+makeLensesSuffixed ''BuildInfo
 
-makeLensesWith suffixedFields ''CondTree
+makeLensesSuffixed ''CondTree
+
+-- | a traversal into the library stanza 
+packageLibraryL :: Traversal' PackageDescription Library
+packageLibraryL = libraryL.each
+
+-- | a traversal into the @exposes-modules@ field of the library stanza 
+packageExposedModulesL :: Traversal' PackageDescription ModuleName
+packageExposedModulesL = packageLibraryL.exposedModulesL.each
+
+-- | a traversal into the @hs-sources@ field of the library stanza 
+packageHsSourcesDirsL :: Traversal' PackageDescription FilePath
+packageHsSourcesDirsL = packageLibraryL.libBuildInfoL.hsSourceDirsL.each
 

--- a/lib/CabalLenses/PackageDescription.hs
+++ b/lib/CabalLenses/PackageDescription.hs
@@ -5,6 +5,7 @@
 -- All lenses are named after their field names with a 'L' appended.
 
 module CabalLenses.PackageDescription where
+import CabalLenses.TH (suffixedFields) 
 
 import Distribution.PackageDescription ( GenericPackageDescription(..)
                                        , PackageDescription(..)
@@ -15,90 +16,28 @@ import Distribution.PackageDescription ( GenericPackageDescription(..)
                                        , BuildInfo(..)
                                        , CondTree(..)
                                        )
-import Control.Lens (makeLensesFor)
+import Control.Lens (makeLensesWith)
 
 
-makeLensesFor [ ("packageDescription", "packageDescriptionL")
-              , ("genPackageFlags"   , "genPackageFlagsL")
-              , ("condLibrary"       , "condLibraryL")
-              , ("condExecutables"   , "condExecutablesL")
-              , ("condTestSuites"    , "condTestSuitesL")
-              , ("condBenchmarks"    , "condBenchmarksL")
-              ] ''GenericPackageDescription
+makeLensesWith suffixedFields ''GenericPackageDescription
 
 
-makeLensesFor [ ("package"       , "packageL")
-              , ("license"       , "licenseL")
-              , ("licenseFile"   , "licenseFileL")
-              , ("copyright"     , "copyrightL")
-              , ("maintainer"    , "maintainerL")
-              , ("author"        , "authorL")
-              , ("stability"     , "stabilityL")
-              , ("testedWith"    , "testedWithL")
-              , ("homepage"      , "homepageL")
-              , ("pkgUrl"        , "pkgUrlL")
-              , ("bugReports"    , "bugReports")
-              , ("sourceRepos"   , "sourceReposL")
-              , ("synopsis"      , "synopsisL")
-              , ("description"   , "descriptionL")
-              , ("category"      , "categoryL")
-              , ("customFieldsPD", "customFieldsPDL")
-              , ("buildDepends"  , "buildDependsL")
-              , ("specVersionRaw", "specVersionRawL")
-              , ("buildType"     , "buildTypeL")
-              , ("library"       , "libraryL")
-              , ("executables"   , "executablesL")
-              , ("testSuites"    , "testSuitesL")
-              , ("benchmarks"    , "benchmarksL")
-              , ("dataFiles"     , "dataFilesL")
-              , ("dataDir"       , "dataDirL")
-              , ("extraSrcFiles" , "extraSrcFilesL")
-              , ("extraTmpFiles" , "extraTmpFilesL")
-              ] ''PackageDescription
+makeLensesWith suffixedFields ''PackageDescription
 
 
-makeLensesFor [ ("exposedModules", "exposedModulesL")
-              , ("libExposed"    , "libExposedL")
-              , ("libBuildInfo"  , "libBuildInfoL")
-              ] ''Library
+makeLensesWith suffixedFields ''Library
 
 
-makeLensesFor [ ("exeName"   , "exeNameL")
-              , ("modulePath", "modulePathL")
-              , ("buildInfo" , "buildInfoL")
-              ] ''Executable
+makeLensesWith suffixedFields ''Executable
 
 
-makeLensesFor [ ("testName"     , "testNameL")
-              , ("testInterface", "testInterfaceL")
-              , ("testBuildInfo", "testBuildInfoL")
-              , ("testEnabled"  , "testEnabledL")
-              ] ''TestSuite
+makeLensesWith suffixedFields ''TestSuite
 
 
-makeLensesFor [ ("benchmarkName", "benchmarkNameL")
-              , ("benchmarkInterface", "benchmarkInterfaceL")
-              , ("benchmarkBuildInfo", "benchmarkBuildInfoL")
-              , ("benchmarkEnabled"  , "benchmarkEnabledL")
-              ] ''Benchmark
+makeLensesWith suffixedFields ''Benchmark
 
 
-makeLensesFor [ ("hsSourceDirs"      , "hsSourceDirsL")
-              , ("options"           , "optionsL")
-              , ("defaultLanguage"   , "defaultLanguageL")
-              , ("cppOptions"        , "cppOptionsL")
-              , ("cSources"          , "cSourcesL")
-              , ("ccOptions"         , "ccOptionsL")
-              , ("extraLibDirs"      , "extraLibDirsL")
-              , ("extraLibs"         , "extraLibsL")
-              , ("ldOptions"         , "ldOptionsL")
-              , ("includeDirs"       , "includeDirsL")
-              , ("includes"          , "includesL")
-              , ("targetBuildDepends", "targetBuildDependsL")
-              ] ''BuildInfo
+makeLensesWith suffixedFields ''BuildInfo
 
 
-makeLensesFor [ ("condTreeData"       , "condTreeDataL")
-              , ("condTreeConstraints", "condTreeConstraintsL")
-              , ("condTreeComponents" , "condTreeComponentsL")
-              ] ''CondTree
+makeLensesWith suffixedFields ''CondTree

--- a/lib/CabalLenses/Section.hs
+++ b/lib/CabalLenses/Section.hs
@@ -1,4 +1,6 @@
+{-| 
 
+-}
 module CabalLenses.Section
    ( Section(..)
    , allSections

--- a/lib/CabalLenses/TH.hs
+++ b/lib/CabalLenses/TH.hs
@@ -2,10 +2,16 @@ module CabalLenses.TH where
 
 import Control.Lens
 
-import Language.Haskell.TH.Syntax (Name, mkName, nameBase) 
+import Language.Haskell.TH (DecsQ, Name, mkName, nameBase) 
 
 
--- | a field called @"fieldName"@ makes a lens called @"fieldNameL"@
+{-| @makeLensesSuffixed = 'makeLensesWith' 'suffixedFields'@ 
+
+-}
+makeLensesSuffixed :: Name -> DecsQ
+makeLensesSuffixed = makeLensesWith suffixedFields 
+
+-- | a field called @"field"@ makes a lens called @"fieldL"@
 suffixedFields :: LensRules
 suffixedFields = defaultFieldRules & lensField .~ suffixedNamer "L"
 

--- a/lib/CabalLenses/TH.hs
+++ b/lib/CabalLenses/TH.hs
@@ -12,5 +12,5 @@ suffixedFields = defaultFieldRules & lensField .~ suffixedNamer "L"
 -- | accepts all fields, and suffixes them with the given suffix
 suffixedNamer :: String -> Name -> [Name] -> Name -> [DefName]
 suffixedNamer suffix _typeName _fieldNames fieldName =
- [TopName$ mkName (nameBase fieldName ++ suffix)]
+ [TopName (mkName (nameBase fieldName ++ suffix))]
 

--- a/lib/CabalLenses/TH.hs
+++ b/lib/CabalLenses/TH.hs
@@ -1,0 +1,16 @@
+module CabalLenses.TH where
+
+import Control.Lens
+
+import Language.Haskell.TH.Syntax (Name, mkName, nameBase) 
+
+
+-- | a field called @"fieldName"@ makes a lens called @"fieldNameL"@
+suffixedFields :: LensRules
+suffixedFields = defaultFieldRules & lensField .~ suffixedNamer "L"
+
+-- | accepts all fields, and suffixes them with the given suffix
+suffixedNamer :: String -> Name -> [Name] -> Name -> [DefName]
+suffixedNamer suffix _typeName _fieldNames fieldName =
+ [TopName$ mkName (nameBase fieldName ++ suffix)]
+

--- a/lib/CabalLenses/Traversals/BuildInfo.hs
+++ b/lib/CabalLenses/Traversals/BuildInfo.hs
@@ -1,5 +1,7 @@
-{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE Rank2Types, CPP #-}
+{-| 
 
+-}
 module CabalLenses.Traversals.BuildInfo
    ( allBuildInfo
    , buildInfo
@@ -12,6 +14,10 @@ import CabalLenses.CondVars (CondVars)
 import CabalLenses.PackageDescription
 import Control.Lens
 import Distribution.PackageDescription (GenericPackageDescription(GenericPackageDescription), BuildInfo)
+
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>), (<*>), pure)
+#endif
 
 -- | A traversal for all 'BuildInfo' of all 'Section'
 allBuildInfo :: Traversal' GenericPackageDescription BuildInfo

--- a/lib/CabalLenses/Traversals/BuildInfo.hs
+++ b/lib/CabalLenses/Traversals/BuildInfo.hs
@@ -7,11 +7,10 @@ module CabalLenses.Traversals.BuildInfo
    ) where
 
 import CabalLenses.Section (Section(..))
-import CabalLenses.Traversals.Internal (traverseData, traverseDataIf)
+import CabalLenses.Traversals.Internal (traverseData, traverseDataIf, having)
 import CabalLenses.CondVars (CondVars)
 import CabalLenses.PackageDescription
 import Control.Lens
-import Control.Applicative ((<$>), (<*>), pure)
 import Distribution.PackageDescription (GenericPackageDescription(GenericPackageDescription), BuildInfo)
 
 -- | A traversal for all 'BuildInfo' of all 'Section'
@@ -39,5 +38,3 @@ buildInfoIf condVars (Executable name) = condExecutablesL . traverse . having na
 buildInfoIf condVars (TestSuite name)  = condTestSuitesL . traverse . having name . _2 . traverseDataIf condVars . testBuildInfoL
 buildInfoIf condVars (Benchmark name)  = condBenchmarksL . traverse . having name . _2 . traverseDataIf condVars . benchmarkBuildInfoL
 
-
-having name = filtered ((== name) . fst)

--- a/lib/CabalLenses/Traversals/Dependency.hs
+++ b/lib/CabalLenses/Traversals/Dependency.hs
@@ -8,11 +8,10 @@ module CabalLenses.Traversals.Dependency
    ) where
 
 import CabalLenses.Section (Section(..))
-import CabalLenses.Traversals.Internal (traverseDependency, traverseDependencyIf)
+import CabalLenses.Traversals.Internal (traverseDependency, traverseDependencyIf, having)
 import CabalLenses.CondVars (CondVars)
 import CabalLenses.PackageDescription
 import Control.Lens
-import Control.Applicative ((<$>), (<*>), pure)
 import Distribution.PackageDescription (GenericPackageDescription(GenericPackageDescription))
 import Distribution.Package (Dependency)
 
@@ -54,5 +53,3 @@ dependencyIf condVars (Executable name) = condExecutablesL . traverse . having n
 dependencyIf condVars (TestSuite name)  = condTestSuitesL . traverse . having name . _2 . traverseDependencyIf condVars
 dependencyIf condVars (Benchmark name)  = condBenchmarksL . traverse . having name . _2 . traverseDependencyIf condVars
 
-
-having name = filtered ((== name) . fst)

--- a/lib/CabalLenses/Traversals/Dependency.hs
+++ b/lib/CabalLenses/Traversals/Dependency.hs
@@ -1,5 +1,7 @@
-{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE Rank2Types, CPP #-}
+{-| 
 
+-}
 module CabalLenses.Traversals.Dependency
    ( allDependency
    , allDependencyIf
@@ -14,6 +16,10 @@ import CabalLenses.PackageDescription
 import Control.Lens
 import Distribution.PackageDescription (GenericPackageDescription(GenericPackageDescription))
 import Distribution.Package (Dependency)
+
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>), (<*>), pure)
+#endif
 
 
 -- | A traversal for all 'Dependency' of all 'Section'.

--- a/lib/CabalLenses/Traversals/Internal.hs
+++ b/lib/CabalLenses/Traversals/Internal.hs
@@ -1,5 +1,7 @@
-{-# LANGUAGE TupleSections, Rank2Types #-}
+{-# LANGUAGE TupleSections, Rank2Types, CPP #-}
+{-| 
 
+-}
 module CabalLenses.Traversals.Internal
    ( traverseDataIf
    , traverseData
@@ -15,8 +17,11 @@ import Distribution.Package (Dependency(..))
 
 import Control.Lens (Traversal',Optic',Choice,filtered)
 
-type CondTree' a = CondTree ConfVar [Dependency] a
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>), (<*>), pure)
+#endif
 
+type CondTree' a = CondTree ConfVar [Dependency] a
 
 -- | A traversal for all 'condTreeData' of 'CondTree' that match 'CondVars'.
 traverseDataIf :: CondVars -> Traversal' (CondTree' dat) dat

--- a/lib/CabalLenses/Traversals/Internal.hs
+++ b/lib/CabalLenses/Traversals/Internal.hs
@@ -5,15 +5,15 @@ module CabalLenses.Traversals.Internal
    , traverseData
    , traverseDependencyIf
    , traverseDependency
+   , having 
    ) where
 
 import CabalLenses.CondVars (CondVars)
 import qualified CabalLenses.CondVars as CV
 import Distribution.PackageDescription (CondTree(..), ConfVar)
 import Distribution.Package (Dependency(..))
-import Data.Traversable (traverse)
-import Control.Applicative (pure, (<$>), (<*>))
-import Control.Lens (Traversal')
+
+import Control.Lens (Traversal',Optic',Choice,filtered)
 
 type CondTree' a = CondTree ConfVar [Dependency] a
 
@@ -23,9 +23,10 @@ traverseDataIf :: CondVars -> Traversal' (CondTree' dat) dat
 traverseDataIf condVars f (CondNode dat constr comps) =
    CondNode <$> f dat
             <*> pure constr
-            <*> (traverse . traverseCompIf condVars) f comps  
-   where
-      traverseCompIf condVars f (cond, ifComp, elseComp) =
+            <*> traverse traverseCompDataIf comps  
+
+   where 
+   traverseCompDataIf (cond, ifComp, elseComp) =
          (,,) <$> pure cond <*> ifComp' <*> elseComp'
          where
             ifComp' | condMatches = traverseDataIf condVars f ifComp
@@ -42,9 +43,10 @@ traverseData :: Traversal' (CondTree' dat) dat
 traverseData f (CondNode dat constr comps) =
    CondNode <$> f dat
             <*> pure constr
-            <*> (traverse . traverseComp) f comps
-   where
-      traverseComp f (cond, ifComp, elseComp) =
+            <*> traverse traverseDataComp comps
+
+   where 
+   traverseDataComp (cond, ifComp, elseComp) =
          (,,) <$> pure cond <*> traverseData f ifComp <*> (traverse . traverseData) f elseComp
 
 
@@ -53,9 +55,10 @@ traverseDependencyIf :: CondVars -> Traversal' (CondTree' dat) Dependency
 traverseDependencyIf condVars f (CondNode dat constr comps) =
    CondNode <$> pure dat
             <*> traverse f constr
-            <*> (traverse . traverseCompIf condVars) f comps  
-   where
-      traverseCompIf condVars f (cond, ifComp, elseComp) =
+            <*> traverse traverseCompDependencyIf comps  
+
+   where 
+   traverseCompDependencyIf (cond, ifComp, elseComp) =
          (,,) <$> pure cond <*> ifComp' <*> elseComp'
          where
             ifComp' | condMatches = traverseDependencyIf condVars f ifComp
@@ -66,13 +69,19 @@ traverseDependencyIf condVars f (CondNode dat constr comps) =
 
             condMatches = CV.eval condVars cond
 
-
 -- | A traversal for all 'condTreeConstraints' (the if and else branches) of the 'CondTree'.
 traverseDependency :: Traversal' (CondTree' dat) Dependency
 traverseDependency f (CondNode dat constr comps) =
    CondNode <$> pure dat
             <*> traverse f constr
-            <*> (traverse . traverseComp) f comps
-   where
-      traverseComp f (cond, ifComp, elseComp) =
+            <*> traverse traverseDependencyComp comps
+
+   where 
+   traverseDependencyComp (cond, ifComp, elseComp) =
          (,,) <$> pure cond <*> traverseDependency f ifComp <*> (traverse . traverseDependency) f elseComp
+
+
+-- | 
+having :: (Eq a, Choice p, Applicative f) => a -> Optic' p f (a, b) (a, b) 
+having name = filtered ((== name) . fst)
+

--- a/lib/CabalLenses/Utils.hs
+++ b/lib/CabalLenses/Utils.hs
@@ -1,4 +1,4 @@
-{-# Language CPP #-}
+{-# Language CPP, PatternGuards  #-}
 
 module CabalLenses.Utils
    ( findCabalFile
@@ -6,7 +6,7 @@ module CabalLenses.Utils
    , findDistDir
    ) where
 
-import Control.Monad.Trans.Either (EitherT, left, right, runEitherT)
+import Control.Monad.Trans.Either (EitherT, left, right)
 import Control.Monad.IO.Class
 import Control.Monad (filterM)
 import qualified System.IO.Strict as Strict
@@ -28,9 +28,9 @@ io = liftIO
 -- | Find a cabal file starting at the given directory, going upwards the directory
 --   tree until a cabal file could be found. The returned file path is absolute.
 findCabalFile :: FilePath -> EitherT Error IO FilePath
-findCabalFile file = do
+findCabalFile theFile = do
    cabalFile <- io $ do
-      dir <- absoluteDirectory file
+      dir <- absoluteDirectory theFile
       findCabalFile' dir
 
    if cabalFile == FP.empty
@@ -78,9 +78,9 @@ findPackageDB cabalFile = do
       -- | reads the 'package-db: ' field from the sandbox config file and returns the value of the field
       readPackageDB :: FP.FilePath -> IO (Maybe FP.FilePath)
       readPackageDB sandboxConfig = do
-         lines <- lines <$> Strict.readFile (FP.encodeString sandboxConfig)
+         theLines <- lines <$> Strict.readFile (FP.encodeString sandboxConfig)
          return $ do
-            line      <- L.find (package_db `L.isPrefixOf`) lines
+            line      <- L.find (package_db `L.isPrefixOf`) theLines 
             packageDB <- L.stripPrefix package_db line
             return $ FP.decodeString packageDB
 

--- a/lib/CabalLenses/Utils.hs
+++ b/lib/CabalLenses/Utils.hs
@@ -1,4 +1,4 @@
-{-# Language CPP, PatternGuards  #-}
+{-# Language CPP, PatternGuards #-}
 
 module CabalLenses.Utils
    ( findCabalFile

--- a/lib/CabalLenses/Version.hs
+++ b/lib/CabalLenses/Version.hs
@@ -5,15 +5,14 @@
 -- All lenses are named after their field names with a 'L' appended.
 
 module CabalLenses.Version where
+import CabalLenses.TH (suffixedFields) 
 
 import Distribution.Version
 import Control.Lens
 import Data.Maybe (fromMaybe)
 
 
-makeLensesFor [ ("versionBranch", "versionBranchL")
-              , ("versionTags"  , "versionTagsL")
-              ] ''Version
+makeLensesWith suffixedFields ''Version
 
 
 intervals :: Iso' VersionRange [VersionInterval]

--- a/lib/CabalLenses/Version.hs
+++ b/lib/CabalLenses/Version.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell, CPP #-}
 
 -- |
 -- Lenses for several data types of the 'Distribution.Version' module.
@@ -11,6 +11,9 @@ import Distribution.Version
 import Control.Lens
 import Data.Maybe (fromMaybe)
 
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>))
+#endif
 
 makeLensesWith suffixedFields ''Version
 

--- a/lib/CabalLenses/Version.hs
+++ b/lib/CabalLenses/Version.hs
@@ -5,7 +5,7 @@
 -- All lenses are named after their field names with a 'L' appended.
 
 module CabalLenses.Version where
-import CabalLenses.TH (suffixedFields) 
+import CabalLenses.TH (makeLensesSuffixed) 
 
 import Distribution.Version
 import Control.Lens
@@ -15,7 +15,7 @@ import Data.Maybe (fromMaybe)
 import Control.Applicative ((<$>))
 #endif
 
-makeLensesWith suffixedFields ''Version
+makeLensesSuffixed ''Version
 
 
 intervals :: Iso' VersionRange [VersionInterval]

--- a/lib/CabalLenses/Version.hs
+++ b/lib/CabalLenses/Version.hs
@@ -9,7 +9,6 @@ module CabalLenses.Version where
 import Distribution.Version
 import Control.Lens
 import Data.Maybe (fromMaybe)
-import Control.Applicative ((<$>))
 
 
 makeLensesFor [ ("versionBranch", "versionBranchL")
@@ -20,8 +19,8 @@ makeLensesFor [ ("versionBranch", "versionBranchL")
 intervals :: Iso' VersionRange [VersionInterval]
 intervals = iso asVersionIntervals toVersionRange
    where
-      toVersionRange intervals =
-         fromMaybe anyVersion (fromVersionIntervals <$> mkVersionIntervals intervals)
+      toVersionRange theIntervals =
+         fromMaybe anyVersion (fromVersionIntervals <$> mkVersionIntervals theIntervals)
 
 
 lowerBound :: Lens' VersionInterval LowerBound
@@ -31,15 +30,15 @@ lowerBound = _1
 version :: Lens' LowerBound Version
 version = lens getVersion setVersion
    where
-      getVersion (LowerBound vers _)          = vers
-      setVersion (LowerBound _    bound) vers = LowerBound vers bound
+      getVersion (LowerBound theVersion _)          = theVersion
+      setVersion (LowerBound _ theBound) theVersion = LowerBound theVersion theBound 
 
 
 bound :: Lens' LowerBound Bound
 bound = lens getBound setBound
    where
-      getBound (LowerBound _ bound)      = bound
-      setBound (LowerBound vers _) bound = LowerBound vers bound
+      getBound (LowerBound _ theBound)            = theBound
+      setBound (LowerBound theVersion _) theBound = LowerBound theVersion theBound
 
 
 upperBound :: Lens' VersionInterval UpperBound
@@ -48,3 +47,4 @@ upperBound = _2
 
 noLowerBound :: LowerBound
 noLowerBound = LowerBound (Version [0] []) InclusiveBound
+


### PR DESCRIPTION
1. let me know if it works on older GHC 

2. I exposed CabalLenses.Traversals.Internal. by convention, ".Internal" modules can violate the PVP. simplifies extension and documentation. 

3. let me know if you don't want the -Wall flag 

4. there are several local variable name changes to prevent various shattering warnings 

