### PR TITLE
Support cabal 3, lens 4.19

### DIFF
--- a/cabal-lenses.cabal
+++ b/cabal-lenses.cabal
@@ -40,9 +40,9 @@ library
     ghc-options: -W
     build-depends:
         base >=4.8 && <5,
-        lens >=4.0.1 && <4.18,
+        lens >=4.0.1 && <4.20,
         unordered-containers >=0.2.3.3 && <0.3,
-        Cabal >=2.1.0.0 && <2.5,
+        Cabal >=3.0.0.0 && <4.0,
         system-filepath >=0.4.9 && <0.5,
         system-fileio >=0.3.12 && <0.4,
         strict >=0.3.2 && <0.4,

--- a/lib/CabalLenses/Package.hs
+++ b/lib/CabalLenses/Package.hs
@@ -29,12 +29,12 @@ instance Wrapped PackageName where
 packageName :: Lens' Dependency PackageName
 packageName = lens getPkgName setPkgName
    where
-      getPkgName (Dependency pkgName _)          = pkgName
-      setPkgName (Dependency _ range) newPkgName = Dependency newPkgName range
+      getPkgName (Dependency pkgName _ _)                 = pkgName
+      setPkgName (Dependency _ range libNames) newPkgName = Dependency newPkgName range libNames
 
 
 versionRange :: Lens' Dependency VersionRange
 versionRange = lens getRange setRange
    where
-      getRange (Dependency _ range)   = range
-      setRange (Dependency pkgName _) = Dependency pkgName
+      getRange (Dependency _ range _)                   = range
+      setRange (Dependency pkgName _ libNames) newRange = Dependency pkgName newRange libNames


### PR DESCRIPTION
Migrated to Cabal 3 which requires `(Set LibraryName)` for `Dependency`.